### PR TITLE
Fix make deleting files that aren't actually intermediate.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MD5 := md5sum -c --quiet
 .SUFFIXES:
 .PHONY: all clean crystal crystal11
 .SECONDEXPANSION:
-.PRECIOUS: %.2bpp %.1bpp
+.PRECIOUS: %.2bpp %.1bpp %.blk %.bin %.tilemap
 
 poketools := extras/pokemontools
 gfx       := $(PYTHON) gfx.py


### PR DESCRIPTION
make was deciding that a couple .blk files were actually intermediate.
Still don't know what is causing that issue. This is a temporary fix
that will probably be forgotten about and become a permanent one.